### PR TITLE
feat: dash or underscore config file options

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,21 +602,21 @@ dependencies:
 [tool.pyproject2conda]
 channels = ['conda-forge']
 # these are the same as the default values of `p2c project`
-template_python = "py{py}-{env}"
+template-python = "py{py}-{env}"
 template = "{env}"
 style = "yaml"
 # options
 python = ["3.10"]
 # Note that this is relative to the location of pyproject.toml
-user_config = "config/userconfig.toml"
+user-config = "config/userconfig.toml"
 # These environments will be created with the package, package dependencies, and
 # dependencies from groups or extras with environment name so the below is the
 # same as
 #
 # [tool.pyproject2conda.envs.test]
-# extras_or_groups = "test"
+# extras-or-groups = "test"
 #
-default_envs = ["test", "dev", "dist-pypi"]
+default-envs = ["test", "dev", "dist-pypi"]
 
 [tool.pyproject2conda.envs.base]
 style = ["requirements"]
@@ -624,14 +624,14 @@ style = ["requirements"]
 # This will have no extras or groups
 #
 # A value of `extras = true` will would be equivalent to
-# passing extras_or_groups = <env-name>
+# passing extras-or-groups = <env-name>
 [tool.pyproject2conda.envs."test-extras"]
 extras = ["test"]
 style = ["yaml", "requirements"]
 
 [[tool.pyproject2conda.overrides]]
 envs = ['test-extras', "dist-pypi"]
-skip_package = true
+skip-package = true
 
 [[tool.pyproject2conda.overrides]]
 envs = ["test", "test-extras"]
@@ -730,21 +730,21 @@ in the `[tool.pyproject2conda]` section. For example, example the configuration:
 [tool.pyproject2conda]
 channels = ['conda-forge']
 # these are the same as the default values of `p2c project`
-template_python = "py{py}-{env}"
+template-python = "py{py}-{env}"
 template = "{env}"
 style = "yaml"
 # options
 python = ["3.10"]
 # Note that this is relative to the location of pyproject.toml
-user_config = "config/userconfig.toml"
+user-config = "config/userconfig.toml"
 # These environments will be created with the package, package dependencies, and
 # dependencies from groups or extras with environment name so the below is the
 # same as
 #
 # [tool.pyproject2conda.envs.test]
-# extras_or_groups = "test"
+# extras-or-groups = "test"
 #
-default_envs = ["test", "dev", "dist-pypi"]
+default-envs = ["test", "dev", "dist-pypi"]
 
 [tool.pyproject2conda.envs.base]
 style = ["requirements"]
@@ -752,14 +752,14 @@ style = ["requirements"]
 # This will have no extras or groups
 #
 # A value of `extras = true` will would be equivalent to
-# passing extras_or_groups = <env-name>
+# passing extras-or-groups = <env-name>
 [tool.pyproject2conda.envs."test-extras"]
 extras = ["test"]
 style = ["yaml", "requirements"]
 
 [[tool.pyproject2conda.overrides]]
 envs = ['test-extras', "dist-pypi"]
-skip_package = true
+skip-package = true
 
 [[tool.pyproject2conda.overrides]]
 envs = ["test", "test-extras"]
@@ -831,11 +831,14 @@ Note that here, we have used the `--dry` option to just print the output. In
 production, you'd omit this flag, and files according to `--template` and
 `--template-python` would be used.
 
-The options under `[tool.pyproject2conda]` follow the command line options
-(replace `-` with `_`). To specify an environment, you can either use the
-`[tool.pyproject.envs."environment-name"]` method, or, if the environment is the
-same as an `project.optional-dependencies` or `dependency-grroups`, you can just
-specify it under `tool.pyproject2conda.default_envs`:
+The options under `[tool.pyproject2conda]` follow the command line options. For
+example, specify `template-python = ...` in the config file instead of passing
+`--template-python`. You can optionally replace all dashes with underscores in
+config file option names if you wish. To specify an environment, you can either
+use the `[tool.pyproject.envs."environment-name"]` method, or, if the
+environment is the same as an `project.optional-dependencies` or
+`dependency-groups`, you can just specify it under
+`tool.pyproject2conda.default_envs`:
 
 ```toml
 [tool.pyproject2conda]
@@ -892,7 +895,7 @@ environment definition, and finally, from the default options.
 You can also define "user defined" configurations. This can be done through the
 option `--user-config`. This allows you to define your own environments outside
 of the (most likely source controlled) `pyproject.toml` file. For example, we
-have the option `user_config=config/userconfig.toml`.
+have the option `user-config=config/userconfig.toml`.
 
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable-next-line MD013 -->
@@ -909,7 +912,7 @@ name = "hello"
 <!-- [[[end]]] -->
 <!-- prettier-ignore-end -->
 
-Note that the full path of this file is note that the path of the `user_config`
+Note that the full path of this file is note that the path of the `user-config`
 file is relative to them`pyproject.toml` file. So, if the `pyproject.toml` file
 is at `a/path/pyproject.toml`, the path of user configuration files will be
 `a/path/config/userconfig.toml`. We then can run the following:

--- a/changelog.d/20250605_152416_wpk_dash_or_underscore.md
+++ b/changelog.d/20250605_152416_wpk_dash_or_underscore.md
@@ -1,0 +1,48 @@
+<!-- markdownlint-disable MD041 -->
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+
+### Changed
+
+- The config file version of command line options now accept either dashes or
+  underscores. For example, the command line option `--template-python` now
+  respects either `template-python` or `template_python` in the
+  `tool.pyproject2conda` table of `pyproject.toml`. Note that you have to use
+  either all dashes or all underscores, not a mix. The parser first looks for
+  options with dashes, then falls back to underscores, so if they are both
+  present, the dashed version will win.
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/pyproject2conda/cli.py
+++ b/src/pyproject2conda/cli.py
@@ -20,7 +20,6 @@ from typer.core import TyperGroup
 from pyproject2conda import __version__
 from pyproject2conda.requirements import ParseDepends
 from pyproject2conda.utils import (
-    conda_env_name_from_template,
     parse_pythons,
     update_target,
 )
@@ -116,10 +115,10 @@ def main(
     ] = None,
 ) -> None:
     """
-    Extract conda `environment.yaml` and pip `requirement.txt` files from `pyproject.toml`
+    Extract conda ``environment.yaml`` and pip ``requirement.txt`` files from ``pyproject.toml``
 
     Note that all subcommands can be called with shortest possible match. Also, you can
-    call with any of `pyproject2conda`, `p2c`, `python -m pyproject2conda`.
+    call with any of ``pyproject2conda``, ``p2c``, ``python -m pyproject2conda``.
     For example,
 
     .. code-block:: console
@@ -151,9 +150,9 @@ EXTRAS_CLI = Annotated[
         "--extra",
         "-e",
         help="""
-        Include dependencies from extra <extra> from `project.optional-dependencies` table of `pyproject.toml`.
+        Include dependencies from extra <extra> from ``project.optional-dependencies`` table of ``pyproject.toml``.
         Can specify multiple times for multiple extras.
-        Use name `extras` for specifying in `pyproject.toml`
+        Use name ``extras`` for specifying in ``pyproject.toml``
         """,
     ),
 ]
@@ -163,9 +162,9 @@ GROUPS_CLI = Annotated[
         "--group",
         "-g",
         help="""
-        Include dependencies from group <group> from `dependency-groups` table of `pyproject.toml`.
+        Include dependencies from group <group> from ``dependency-groups`` table of ``pyproject.toml``.
         Can specify multiple times for multiple groups.
-        Use name `groups` for specifying in `pyproject.toml`
+        Use name ``groups`` for specifying in ``pyproject.toml``
         """,
     ),
 ]
@@ -174,10 +173,10 @@ EXTRAS_OR_GROUPS_CLI = Annotated[
     typer.Option(  # pyright: ignore[reportUnknownMemberType]
         "--extra-or-group",
         help="""
-        Include dependencies from extra or group of `pyproject.toml`.
-        Extras are checked first, followed by groups.  The first instance of `extra-or-group` found is used.
-        That is, if both `extras` and `groups` contain `extra-or-group`, the extra will be used.
-        Use name `extras_or_groups` for specifying in `pyproject.toml`
+        Include dependencies from extra or group of ``pyproject.toml``.
+        Extras are checked first, followed by groups.  The first instance of ``extra-or-group`` found is used.
+        That is, if both ``extras`` and ``groups`` contain ``extra-or-group``, the extra will be used.
+        Use name ``extras-or-groups`` for specifying in ``pyproject.toml``
         """,
     ),
 ]
@@ -194,10 +193,7 @@ NAME_CLI = Annotated[
     typer.Option(  # pyright: ignore[reportUnknownMemberType]
         "--name",
         "-n",
-        help="""
-        `name` field in generated environment.yaml file.
-        This supports substitution of the fields ``{py_version}`` for the full python version, ``{py}`` for the python version without ``"."``, and ``{env}`` for the environment name (if used with the ``project``) subcommand.
-        """,
+        help="Name of conda env",
     ),
 ]
 OUTPUT_CLI = Annotated[
@@ -211,7 +207,7 @@ OUTPUT_CLI = Annotated[
 
 
 class Overwrite(str, Enum):
-    """Options for `--overwrite`"""
+    """Options for ``--overwrite``"""
 
     check = "check"
     skip = "skip"
@@ -226,7 +222,7 @@ OVERWRITE_CLI = Annotated[
         case_sensitive=False,
         help="""
     What to do if output file exists.
-    (check): Create if missing. If output exists and passed `--filename` is newer, recreate output, else skip.
+    (check): Create if missing. If output exists and passed ``--filename`` is newer, recreate output, else skip.
     (skip): If output exists, skip.
     (force): force: force recreate output.
     """,
@@ -237,7 +233,7 @@ VERBOSE_CLI = Annotated[
     typer.Option(
         "--verbose",
         "-v",
-        help="Pass `-v/--verbose` for verbose output.  Pass multiple times to set verbosity level.",
+        help="Pass ``-v/--verbose`` for verbose output.  Pass multiple times to set verbosity level.",
         count=True,
         callback=_callback_verbose,
     ),
@@ -247,9 +243,9 @@ SKIP_PACKAGE_CLI = Annotated[
     typer.Option(
         "--skip-package",
         help="""
-        Default is to include package dependencies from `project.dependencies`
-        table of `pyproject.toml`. Passing `--skip-package` (or `skip_package =
-        true` in `tool.pyproject2conda.envs...` table of `pyproject.toml`) will
+        Default is to include package dependencies from ``project.dependencies``
+        table of ``pyproject.toml``. Passing ``--skip-package`` (or ``skip_package =
+        true`` in ``tool.pyproject2conda.envs...`` table of ``pyproject.toml``) will
         exclude the package dependencies. This is useful to define environments
         that should exclude base dependencies (like build, etc) in
         pyproject.toml.
@@ -260,7 +256,7 @@ PIP_ONLY_CLI = Annotated[
     bool,
     typer.Option(
         "--pip-only",
-        help="""Treat all requirements as pip requirements. Use option `pip_only` in pyproject.toml""",
+        help="""Treat all requirements as pip requirements. Use option ``pip_only`` in pyproject.toml""",
     ),
 ]
 SORT_DEPENDENCIES_CLI = Annotated[
@@ -268,9 +264,9 @@ SORT_DEPENDENCIES_CLI = Annotated[
     typer.Option(
         "--sort/--no-sort",
         help="""
-        Default is to sort the dependencies (excluding `--python-include`).
-        Pass `--no-sort` to instead place dependencies in order they are
-        gathered.  Use option `sort = true/false` in pyproject.toml
+        Default is to sort the dependencies (excluding ``--python-include``).
+        Pass ``--no-sort`` to instead place dependencies in order they are
+        gathered.  Use option ``sort = true/false`` in pyproject.toml
         """,
     ),
 ]
@@ -280,8 +276,8 @@ PYTHON_INCLUDE_CLI = Annotated[
         "--python-include",
         help="""
         If value passed, use this value (exactly) in the output. So, for
-        example, pass `--python-include "python=3.8"`. Special case is the
-        value `"infer"`. This infers the value of python from `pyproject.toml`
+        example, pass ``--python-include "python=3.8"``. Special case is the
+        value ``"infer"``. This infers the value of python from ``pyproject.toml``
         """,
     ),
 ]
@@ -290,11 +286,11 @@ PYTHON_VERSION_CLI = Annotated[
     typer.Option(
         "--python-version",
         help="""
-         Python version to check `python_version <=> {python_version}` lines
+         Python version to check ``python_version <=> {python_version}`` lines
          against. That is, this version is used to limit packages in resulting
-         output. For example, if have a line like `a-package; python_version <
-         '3.9'`, Using `--python-version 3.10` will not include `a-package`,
-         while `--python-version 3.8` will include `a-package`.
+         output. For example, if have a line like ``a-package; python_version <
+         '3.9'``, Using ``--python-version 3.10`` will not include ``a-package``,
+         while ``--python-version 3.8`` will include ``a-package``.
          """,
     ),
 ]
@@ -304,18 +300,18 @@ PYTHON_CLI = Annotated[
         "--python",
         "-p",
         help="""
-        python version. passing `--python {version}` is equivalent to passing
-        `--python-version={version} --python-include=python{version}`. if
-        passed, this overrides values of passed via `--python-version` and
-        `--python-include`. pass `--python="default"` to include the python
-        version (major.minor only) from, in order, `.python-version-default` or
-        `.python-version`file in the current directory. pass `"lowest"` or
-        `"highest"` to include the lowest or highest python version,
-        respectively, from `pyproject.toml:project.classifiers` table. in
-        project mode, you can pass multiple python version in `pyproject.toml`
-        with, e.g., `python = ["3.8", "3.9", ....]`, or using `python = "all"`,
+        python version. passing ``--python {version}`` is equivalent to passing
+        ``--python-version={version} --python-include=python{version}``. if
+        passed, this overrides values of passed via ``--python-version`` and
+        ``--python-include``. pass ``--python="default"`` to include the python
+        version (major.minor only) from, in order, ``.python-version-default`` or
+        ``.python-version``file in the current directory. pass ``"lowest"`` or
+        ``"highest"`` to include the lowest or highest python version,
+        respectively, from ``pyproject.toml:project.classifiers`` table. in
+        project mode, you can pass multiple python version in ``pyproject.toml``
+        with, e.g., ``python = ["3.8", "3.9", ....]``, or using ``python = "all"``,
         to include all python versions extracted from
-        `pyproject.toml:project.classifiers` table.
+        ``pyproject.toml:project.classifiers`` table.
         """,
     ),
 ]
@@ -335,7 +331,7 @@ CUSTOM_COMMAND_CLI = Annotated[
     typer.Option(
         "--custom-command",
         help="""
-        Custom command to place in header.  Implies `--header`.
+        Custom command to place in header.  Implies ``--header``.
         """,
     ),
 ]
@@ -353,7 +349,7 @@ REQS_CLI = Annotated[
         "--reqs",
         "-r",
         help="""
-        Additional pip requirements. For example, pass `-r '-e .'` to included
+        Additional pip requirements. For example, pass ``-r '-e .'`` to included
         editable version of current package in requirements file.
         """,
     ),
@@ -367,7 +363,7 @@ ENVS_CLI = Annotated[
 TEMPLATE_CLI = Annotated[
     str | None,
     typer.Option(
-        help="Template for environments that do not have a python version. Defaults to `{env}`."
+        help="Template for environments that do not have a python version. Defaults to ``{env}``."
     ),
 ]
 TEMPLATE_PYTHON_CLI = Annotated[
@@ -375,8 +371,8 @@ TEMPLATE_PYTHON_CLI = Annotated[
     typer.Option(
         help="""
         Template for environments that do have a python version. Defaults to
-        "py{py}-{env}". For example, with `--template-python="py{py}-{env}"` and
-        `--python=3.8` and environment "dev", output would be "py38-dev"
+        "py{py}-{env}". For example, with ``--template-python="py{py}-{env}"`` and
+        ``--python=3.8`` and environment "dev", output would be "py38-dev"
         \b
         * {py} -> "38"
         * {py_version} -> "3.8"
@@ -389,7 +385,7 @@ REQS_EXT_CLI = Annotated[
     typer.Option(
         "--reqs-ext",
         help="""
-        Extension to use with requirements file output created from template.  Defaults to `".txt"`.
+        Extension to use with requirements file output created from template.  Defaults to ``".txt"``.
         """,
     ),
 ]
@@ -398,7 +394,7 @@ YAML_EXT_CLI = Annotated[
     typer.Option(
         "--yaml-ext",
         help="""
-        Extension to use with conda environment.yaml file output created from template.  Defaults to `".yaml"`
+        Extension to use with conda environment.yaml file output created from template.  Defaults to ``".yaml"``
         """,
     ),
 ]
@@ -416,8 +412,8 @@ USER_CONFIG_CLI = Annotated[
         help="""
         Additional toml file to supply configuration. This can be used to
         override/add environment files for your own use (apart from project env
-        files). The (default) value `infer` means to infer the configuration
-        from `--filename`.
+        files). The (default) value ``infer`` means to infer the configuration
+        from ``--filename``.
         """,
     ),
 ]
@@ -439,18 +435,18 @@ ALLOW_EMPTY_OPTION = typer.Option(
     "--allow-empty/--no-allow-empty",
     help="""
     What to do if there are no package requirements for an environment. The
-    default (`--no-allow-empty`) is to raise an error if the specification
-    leads to no requirements. Passing `--allow-empty` will lead to a message
+    default (``--no-allow-empty``) is to raise an error if the specification
+    leads to no requirements. Passing ``--allow-empty`` will lead to a message
     being printed, but no environment file being created.
     """,
 )
 REMOVE_WHITESPACE_OPTION = typer.Option(
     "--remove-whitespace/--no-remove-whitespace",
     help="""
-    What to do with whitespace in a dependency. Passing `--remove-whitespace`
+    What to do with whitespace in a dependency. Passing ``--remove-whitespace``
     will remove whitespace in a given dependency. For example, the dependency
-    `package >= 1.0` will be converted to `package>=1.0`. Pass
-    `--no-remove-whitespace` to keep the the whitespace in the output.
+    ``package >= 1.0`` will be converted to ``package>=1.0``. Pass
+    ``--no-remove-whitespace`` to keep the the whitespace in the output.
     """,
 )
 
@@ -569,8 +565,6 @@ def yaml(
         toml_path=pyproject_filename,
     )
 
-    name = conda_env_name_from_template(name=name, python_version=python_version)
-
     d = _get_requirement_parser(pyproject_filename)
 
     _log_creating(logger, "yaml", output)
@@ -616,7 +610,7 @@ def requirements(
     allow_empty: Annotated[bool, ALLOW_EMPTY_OPTION] = False,
     remove_whitespace: Annotated[bool, REMOVE_WHITESPACE_OPTION] = False,
 ) -> None:
-    """Create requirements.txt for pip dependencies.  Note that all requirements are normalized using `packaging.requirements.Requirement`"""
+    """Create requirements.txt for pip dependencies.  Note that all requirements are normalized using ``packaging.requirements.Requirement``"""
     if not update_target(output, pyproject_filename, overwrite=overwrite.value):
         _log_skipping(logger, "requirements", output)
         return
@@ -651,7 +645,6 @@ def project(
     envs: ENVS_CLI = None,
     template: TEMPLATE_CLI = None,
     template_python: TEMPLATE_PYTHON_CLI = None,
-    name: NAME_CLI = None,
     reqs: REQS_CLI = None,
     deps: DEPS_CLI = None,
     reqs_ext: REQS_EXT_CLI = ".txt",
@@ -667,7 +660,17 @@ def project(
     allow_empty: Annotated[bool | None, ALLOW_EMPTY_OPTION] = None,
     remove_whitespace: Annotated[bool | None, REMOVE_WHITESPACE_OPTION] = None,
 ) -> None:
-    """Create multiple environment files from `pyproject.toml` specification."""
+    """
+    Create multiple environment files from ``pyproject.toml`` specification.
+
+    Note that if you specify options in ``pyproject.toml``, the name is usually
+    the same as the command line option. You can replace dashes with
+    underscores if you wish, but if you do so, replace all dashes with
+    underscores. For cases where the option can take multiple values, the
+    config file option will be plural. For example, the command line option
+    ``--group`` becomes the config file option ``groups = ...``.  Boolean options
+    like ``--sort/--no-sort`` become ``sort = true/false`` in the config file.
+    """
     from pyproject2conda.config import Config
 
     c = Config.from_file(pyproject_filename, user_config=user_config)
@@ -690,7 +693,6 @@ def project(
         verbose=verbose,
         allow_empty=allow_empty,
         remove_whitespace=remove_whitespace,
-        name=name,
         pip_only=pip_only or None,
     ):
         if dry:

--- a/src/pyproject2conda/config.py
+++ b/src/pyproject2conda/config.py
@@ -99,6 +99,15 @@ class Config:  # noqa: PLR0904
                 if value is None:
                     value = self.get_in(key, default=None)
 
+        # For case that key contains a dash, also consider the case where
+        # dashes are underscores
+        if value is None and "-" in key:
+            value = self._get_value(
+                key=key.replace("-", "_"),
+                env_name=env_name,
+                inherit=inherit,
+            )
+
         if value is None:
             value = (
                 default()  # ty: ignore[call-non-callable]
@@ -137,7 +146,7 @@ class Config:  # noqa: PLR0904
     ) -> bool:
         """If True, use pip only"""
         return self._get_value(  # type: ignore[no-any-return]
-            key="pip_only",
+            key="pip-only",
             env_name=env_name,
             inherit=inherit,
             default=default,
@@ -189,7 +198,7 @@ class Config:  # noqa: PLR0904
         These will need to be resolved after the fact.
         """
         return self._get_extras(
-            key="extras_or_groups", env_name=env_name, default=list, inherit=inherit
+            key="extras-or-groups", env_name=env_name, default=list, inherit=inherit
         )
 
     def output(self, env_name: str | None = None) -> str | None:
@@ -206,7 +215,7 @@ class Config:  # noqa: PLR0904
 
     def skip_package(self, env_name: str, default: bool = False) -> bool:
         """skip_package getter."""
-        return self._get_value(key="skip_package", env_name=env_name, default=default)  # type: ignore[no-any-return]
+        return self._get_value(key="skip-package", env_name=env_name, default=default)  # type: ignore[no-any-return]
 
     def name(self, env_name: str) -> str | None:
         """Name option."""
@@ -218,7 +227,7 @@ class Config:  # noqa: PLR0904
 
     def custom_command(self, env_name: str) -> bool:
         """Custom command to place in the header"""
-        return self._get_value(key="custom_command", env_name=env_name, default=None)  # type: ignore[no-any-return]
+        return self._get_value(key="custom-command", env_name=env_name, default=None)  # type: ignore[no-any-return]
 
     def style(self, env_name: str | None = None, default: str = "yaml") -> str:
         """Style getter.  One of `yaml`, `requirements`"""
@@ -233,11 +242,11 @@ class Config:  # noqa: PLR0904
 
     def python_include(self, env_name: str | None = None) -> str | None:
         """Flag python_include"""
-        return self._get_value(key="python_include", env_name=env_name)  # type: ignore[no-any-return]
+        return self._get_value(key="python-include", env_name=env_name)  # type: ignore[no-any-return]
 
     def python_version(self, env_name: str | None = None) -> str | None:
         """Flag python_version"""
-        return self._get_value(key="python_version", env_name=env_name)  # type: ignore[no-any-return]
+        return self._get_value(key="python-version", env_name=env_name)  # type: ignore[no-any-return]
 
     def overwrite(self, env_name: str | None = None, default: str = "check") -> str:
         """Flag overwrite"""
@@ -256,13 +265,13 @@ class Config:  # noqa: PLR0904
     def template_python(self, env_name: str, default: str = "py{py}-{env}") -> str:
         """Flag for template_python."""
         return self._get_value(  # type: ignore[no-any-return]
-            key="template_python", env_name=env_name, default=default
+            key="template-python", env_name=env_name, default=default
         )
 
     def reqs_ext(self, env_name: str, default: str = ".txt") -> str:
         """Requirements extension"""
         return self._get_value(  # type: ignore[no-any-return]
-            key="reqs_ext",
+            key="reqs-ext",
             env_name=env_name,
             default=default,
         )
@@ -270,7 +279,7 @@ class Config:  # noqa: PLR0904
     def yaml_ext(self, env_name: str, default: str = ".yaml") -> str:
         """Conda yaml extension"""
         return self._get_value(  # type: ignore[no-any-return]
-            key="yaml_ext",
+            key="yaml-ext",
             env_name=env_name,
             default=default,
         )
@@ -293,12 +302,12 @@ class Config:  # noqa: PLR0904
 
     def user_config(self, env_name: str | None = None) -> str | None:  # noqa: ARG002
         """Flag user_config"""
-        return self._get_value(key="user_config", default=None)  # type: ignore[no-any-return]
+        return self._get_value(key="user-config", default=None)  # type: ignore[no-any-return]
 
     def allow_empty(self, env_name: str | None = None, default: bool = False) -> bool:
         """Allow empty option."""
         return self._get_value(  # type: ignore[no-any-return]
-            key="allow_empty", env_name=env_name, default=default
+            key="allow-empty", env_name=env_name, default=default
         )
 
     def remove_whitespace(
@@ -306,7 +315,7 @@ class Config:  # noqa: PLR0904
     ) -> bool:
         """Remove whitespace option."""
         return self._get_value(  # type: ignore[no-any-return]
-            key="remove_whitespace",
+            key="remove-whitespace",
             env_name=env_name,
             default=default,
         )
@@ -483,14 +492,15 @@ class Config:  # noqa: PLR0904
         """Create from toml dictionaries."""
         data = get_in(["tool", "pyproject2conda"], data_toml, default={})
 
-        if "default_envs" in data:
-            default_envs = data.pop("default_envs")
+        for key in ("default-envs", "default_envs"):
+            if key in data:
+                default_envs = data.pop(key)
 
-            if "envs" not in data:
-                data["envs"] = {}
+                if "envs" not in data:
+                    data["envs"] = {}
 
-            for env in default_envs:
-                data["envs"][env] = {"extras_or_groups": True}
+                for env in default_envs:
+                    data["envs"][env] = {"extras_or_groups": True}
 
         c = cls(
             data,

--- a/tests/data/test-pyproject.toml
+++ b/tests/data/test-pyproject.toml
@@ -34,21 +34,21 @@ build = { channel = "pip" }
 [tool.pyproject2conda]
 channels = ['conda-forge']
 # these are the same as the default values of `p2c project`
-template_python = "py{py}-{env}"
+template-python = "py{py}-{env}"
 template = "{env}"
 style = "yaml"
 # options
 python = ["3.10"]
 # Note that this is relative to the location of pyproject.toml
-user_config = "config/userconfig.toml"
+user-config = "config/userconfig.toml"
 # These environments will be created with the package, package dependencies, and
 # dependencies from groups or extras with environment name so the below is the
 # same as
 #
 # [tool.pyproject2conda.envs.test]
-# extras_or_groups = "test"
+# extras-or-groups = "test"
 #
-default_envs = ["test", "dev", "dist-pypi"]
+default-envs = ["test", "dev", "dist-pypi"]
 
 [tool.pyproject2conda.envs.base]
 style = ["requirements"]
@@ -56,14 +56,14 @@ style = ["requirements"]
 # This will have no extras or groups
 #
 # A value of `extras = true` will would be equivalent to
-# passing extras_or_groups = <env-name>
+# passing extras-or-groups = <env-name>
 [tool.pyproject2conda.envs."test-extras"]
 extras = ["test"]
 style = ["yaml", "requirements"]
 
 [[tool.pyproject2conda.overrides]]
 envs = ['test-extras', "dist-pypi"]
-skip_package = true
+skip-package = true
 
 [[tool.pyproject2conda.overrides]]
 envs = ["test", "test-extras"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ from pyproject2conda import utils
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+    from pathlib import Path
     from typing import Any
 
 
@@ -34,7 +35,10 @@ def test_template() -> None:
     ],
 )
 def test_default_pythons(
-    example_path, python_version_default, python_version, expected
+    example_path: Path,
+    python_version_default: str,
+    python_version: str,
+    expected: list[str],
 ) -> None:
     for name, version in zip(
         [".python-version-default", ".python-version"],
@@ -74,7 +78,7 @@ def test__get_standard_format_dict(
     env_name: str | None, python_version: str | None, expected: dict[str, str]
 ) -> None:
     assert (
-        utils._get_standard_format_dict(  # noqa: SLF001
+        utils._get_standard_format_dict(  # noqa: SLF001  # pylint: disable=protected-access
             env_name=env_name, python_version=python_version
         )
         == expected
@@ -89,8 +93,8 @@ def test__get_standard_format_dict(
             "3.8",
             "there",
             ".txt",
-            nullcontext("thing-there.txt"),
-        ),  # pyrefly: ignore
+            nullcontext("thing-there.txt"),  # pyrefly: ignore
+        ),
         ("thing-{py}", None, "there", ".yaml", pytest.raises(KeyError)),
     ],
 )
@@ -122,8 +126,8 @@ def test_filename_from_template(
             "my-{env}-{py}",
             "3.8",
             "thing",
-            nullcontext("my-thing-38"),
-        ),  # pyrefly: ignore
+            nullcontext("my-thing-38"),  # pyrefly: ignore
+        ),
     ],
 )
 def test_conda_env_name_from_template(


### PR DESCRIPTION

The config file version of command line options now accept either dashes or
underscores. For example, the command line option `--template-python` now
respects either `template-python` or `template_python` in the
`tool.pyproject2conda` table of `pyproject.toml`. Note that you have to use
either all dashes or all underscores, not a mix. The parser first looks for
options with dashes, then falls back to underscores, so if they are both
present, the dashed version will win.
