### PR TITLE
chore(bump): bump pyproject2conda from 0.23.0 to 0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Changelog for `pyproject2conda`
 
 See the fragment files in [changelog.d]
 
+## 0.23.1
+
+Released on 2026-05-07.
+
+### Bug fixes
+
+- fix: fix bug with deps/reqs aliases ([#103](https://github.com/usnistgov/pyproject2conda/pull/103))
+
+### Contributors
+
+- [@wpk-nist-gov](https://github.com/wpk-nist-gov)
+
 ## 0.23.0
 
 Released on 2026-04-29.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "pyproject2conda"
-version = "0.23.0"
+version = "0.23.1"
 description = "A script to convert a Python project declared on a pyproject.toml to a conda environment."
 readme = "README.md"
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -1363,7 +1363,7 @@ wheels = [
 
 [[package]]
 name = "pyproject2conda"
-version = "0.23.0"
+version = "0.23.1"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },


### PR DESCRIPTION
This is an autogenerated PR. Use this to bump the package version.

You may need to push an empty commit to restart ci (or close and open)