### PR TITLE
chore(bump): bump pyproject2conda from 0.23.1 to 0.23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Changelog for `pyproject2conda`
 
 See the fragment files in [changelog.d]
 
+## 0.23.2
+
+Released on 2026-08-19.
+
+### Bug fixes
+
+- fix: Handle an empty .python-version file ([#225](https://github.com/usnistgov/pyproject2conda/pull/225))
+
+### Contributors
+
+- [@arpitjain099](https://github.com/arpitjain099)
+
 ## 0.23.1
 
 Released on 2026-05-07.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "pyproject2conda"
-version = "0.23.1"
+version = "0.23.2"
 description = "A script to convert a Python project declared on a pyproject.toml to a conda environment."
 readme = "README.md"
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -1455,7 +1455,7 @@ wheels = [
 
 [[package]]
 name = "pyproject2conda"
-version = "0.23.1"
+version = "0.23.2"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },


### PR DESCRIPTION
This is an autogenerated PR. Use this to bump the package version.

You may need to push an empty commit to restart ci (or close and open)